### PR TITLE
GRN2-278: Moved maintenance window to admin settings

### DIFF
--- a/app/assets/javascripts/admins.js
+++ b/app/assets/javascripts/admins.js
@@ -122,6 +122,17 @@ function changeBrandingImage(path) {
   $.post(path, {value: url})
 }
 
+// Display the maintenance window flash
+function displayMaintenanceFlash(path) {
+  var message = $("#maintenance-flash").val()
+  $.post(path, {value: message})
+}
+
+// Clear the maintenance window flash
+function clearMaintenanceFlash(path) {
+  $.post(path, {value: ""})
+}
+
 function mergeUsers() {
   let userToMerge = $("#from-uid").text()
   $.post($("#merge-save-access").data("path"), {merge: userToMerge})

--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -39,7 +39,7 @@
   color: white !important;
 }
 
-#branding-image{
+#settings-button{
   z-index: auto;
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,9 +80,9 @@ class ApplicationController < ActionController::Base
           help: I18n.t("errors.maintenance.help"),
         }
     end
-    if Rails.configuration.maintenance_window.present?
-      unless cookies[:maintenance_window] == Rails.configuration.maintenance_window
-        flash.now[:maintenance] = I18n.t("maintenance.window_alert", date: Rails.configuration.maintenance_window)
+    if @settings.get_value("Maintenance Flash").present?
+      unless cookies[:maintenance_window] == @settings.get_value("Maintenance Flash")
+        flash.now[:maintenance] = I18n.t("maintenance.window_alert", date: @settings.get_value("Maintenance Flash"))
       end
     end
   end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -93,4 +93,9 @@ module AdminsHelper
   def room_is_running(id)
     @running_room_bbb_ids.include?(id)
   end
+
+  def can_edit_maintenance_flash
+    (Rails.configuration.loadbalanced_configuration && current_user.has_role?(:super_admin)) ||
+      (!Rails.configuration.loadbalanced_configuration && current_user.has_role?(:admin))
+  end
 end

--- a/app/helpers/theming_helper.rb
+++ b/app/helpers/theming_helper.rb
@@ -26,4 +26,8 @@ module ThemingHelper
   def user_color
     @settings.get_value("Primary Color") || Rails.configuration.primary_color_default
   end
+
+  def maintenance_flash
+    @settings.get_value("Maintenance Flash")
+  end
 end

--- a/app/views/admins/components/_settings.html.erb
+++ b/app/views/admins/components/_settings.html.erb
@@ -22,7 +22,7 @@
         <div class="input-group">
           <input id="branding-url" type="text" class="form-control" value="<%= logo_image %>">
           <span class="input-group-append">
-            <button id="branding-image" onclick="changeBrandingImage('<%= admin_update_settings_path(setting: 'Branding Image') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.branding.change") %></button>
+            <button id="settings-button" onclick="changeBrandingImage('<%= admin_update_settings_path(setting: 'Branding Image') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.branding.change") %></button>
           </span>
         </div>
       </div>
@@ -141,6 +141,25 @@
       </div>
     </div>
   </div>
+  <% if can_edit_maintenance_flash %>
+   <div class="mb-6 row">
+     <div class="col-12">
+       <div class="form-group">
+         <label class="form-label"><%= t("administrator.site_settings.maintenance_window.title") %></label>
+         <label class="form-label text-muted"><%= t("administrator.site_settings.maintenance_window.info") %></label>
+         <div class="input-group">
+           <input id="maintenance-flash" type="text" class="form-control" value="<%= maintenance_flash %>" placeholder="e.g. Friday, August 18 at 6-10pm EST">
+           <span class="input-group-append">
+             <div>
+              <button id="settings-button" onclick="displayMaintenanceFlash('<%= admin_update_settings_path(setting: 'Maintenance Flash') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.maintenance_window.display") %></button>
+              <button id="settings-button" onclick="clearMaintenanceFlash('<%= admin_update_settings_path(setting: 'Maintenance Flash') %>')" class="btn btn-primary" type="button"><%= t("administrator.site_settings.maintenance_window.clear") %></button>
+             </div>
+           </span>
+         </div>
+       </div>
+     </div>
+   </div>
+  <% end %>
   <div class="mb-6 row">
     <div class="col-12">
       <div class="form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,11 @@ en:
         info: Set the default recording visbility for new recordings
         title: Recording Default Visibility
         warning: This setting will only be applied to rooms that aren't running
+      maintenance_window:
+        info: Displays a flash to inform the user of a scheduled maintenance window
+        title: Maintenance Window
+        display: Display
+        clear: Clear
       registration:
         info: Change the way that users register to the website
         title: Registration Method

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -387,6 +387,24 @@ describe AdminsController, type: :controller do
       end
     end
 
+    context "POST #maintenance_window" do
+      it "displays a flash with the maintenance window date string" do
+        allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)
+        allow_any_instance_of(User).to receive(:greenlight_account?).and_return(true)
+
+        @request.session[:user_id] = @admin.id
+        fake_flash_string = "Sunday January 20 2am-5am EST"
+
+        post :update_settings, params: { setting: "Maintenance Flash", value: fake_flash_string }
+
+        feature = Setting.find_by(provider: "provider1").features.find_by(name: "Maintenance Flash")
+
+        expect(flash[:success]).to be_present
+        expect(feature[:value]).to eq(fake_flash_string)
+        expect(response).to redirect_to(admin_site_settings_path)
+      end
+    end
+
     context "POST #shared_access" do
       it "changes the shared access setting" do
         allow(Rails.configuration).to receive(:loadbalanced_configuration).and_return(true)


### PR DESCRIPTION
GRN2-278: Moved maintenance window to admin settings

GRN2-278: Made maintenance window only for super admins in multitenant

GRN2-278: rubucop fix

GRN2-278: Maintenance window only for super admins while in multitenant

GRN2-278: Made maintenance window only for super admins in multitenant

GRN2-278: Made maintenance window only for super admins in multitenant

GRN2-278: Made maintenance window only for super admins in multitenant

GRN2-278: rubocop fix

GRN2-278: Made maintenance window only for super admins in multitenant